### PR TITLE
Docker files for the content-web, content-api and content-init application (DEVWF-T003)

### DIFF
--- a/content-api/Dockerfile
+++ b/content-api/Dockerfile
@@ -1,0 +1,17 @@
+# Dockerfile for content-api
+# This is the base image that can be used
+FROM node:argon  
+#This is the environment variable with connection to the MongoDB. Can be overriden in the docker run command with the -e switch
+ENV MONGODB_CONNECTION=mongodb://mongo:27017/contentdb
+# This is the directory within the container where commands will be executed
+WORKDIR /usr/src/app 
+# Copy the package json file to the workdir
+COPY package.json /usr/src/app/
+# This is the port that the container exposes
+EXPOSE 3001
+# Run the NPM install command to build the application
+RUN npm install
+# Copy the rest of the sources
+COPY . /usr/src/app
+# Start the application
+CMD [ "npm", "start" ]

--- a/content-init/Dockerfile
+++ b/content-init/Dockerfile
@@ -1,0 +1,14 @@
+# This is the base image that can be used
+FROM node:argon AS build
+#This is the environment variable with connection to the MongoDB. Can be overriden in the docker run command with the -e switch
+ENV MONGODB_CONNECTION=mongodb://mongo:27017/contentdb
+# This is the directory within the container where commands will be executed
+WORKDIR /usr/src/app
+# Copy the package json file to the workdir
+COPY package.json /usr/src/app/
+# Run the NPM install command to build the application
+RUN npm install
+# Copy the rest of the sources
+COPY . /usr/src/app
+# Start the application
+CMD [ "npm", "start" ]

--- a/content-web/Dockerfile
+++ b/content-web/Dockerfile
@@ -1,0 +1,23 @@
+# Dockerfile for content-web
+# This is the base image that can be used
+FROM node:dubnium AS build
+#This is the environment variable with connection to the API. Can be overriden in the docker run command with the -e switch
+ENV CONTENT_API_URL=http://api:3001
+# This is the port that the container exposes
+ENV PORT=80
+# This is the port that the container exposes
+EXPOSE 80
+# Run the NPM install command to install Angular
+RUN npm install -g @angular/cli@~8.3.4
+# This is the directory within the container where commands will be executed
+WORKDIR /usr/src/app
+# Copy the package json file to the workdir
+COPY package.json /usr/src/app/
+# Run the NPM install command to build the application
+RUN npm install
+# Copy the rest of the sources
+COPY . /usr/src/app
+# Build the Angular Application
+RUN ng build 
+# Start the application
+CMD [ "node", "app.js" ]


### PR DESCRIPTION

# Instructions to Fix the exercise

Added these 3 Docker files. I was so excited about this Docker stuff, that I created these 3 files for the API, WEB and INIT application. I think it can be improved, but let's first check if this works!

To build this

```bash
cd content-web
docker build -t fabrikam-web .

cd ../content-init
docker build -t fabrikam-init .

cd ../content-api
docker build -t fabrikam-api .
```

> Before you run the api make sure your MongoDB is running

```bash
docker network create fabrikam
docker run --name mongo --net fabrikam -p 27017:27017 -d mongo
```

To run it

```bash
docker run -ti --network fabrikam fabrikam-init
docker run -d --name api -p 3001:3001 --network fabrikam fabrikam-api
docker run -d --name web -p 3000:80 --network fabrikam fabrikam-web
```
Now you can open the web application by right clicking the running process on port 3000 from the Ports tab in your Codespace.