### PR TITLE
Skip to Task 7 (DEVWF-T004)

### DIFF
--- a/content-api/Dockerfile
+++ b/content-api/Dockerfile
@@ -7,7 +7,7 @@ ENV MONGODB_CONNECTION=mongodb://mongo:27017/contentdb
 FROM node:argon AS build
 WORKDIR /usr/src/app
 
-# Install app dependencies
+# Install app dependenciessss
 COPY package.json /usr/src/app/
 RUN npm install
 


### PR DESCRIPTION

# Instructions to Fix the exercise
Skip to task 7 to show pushing Docker images to GitHub registry without performing the other exercises in module 1

Linked to AB#5055